### PR TITLE
Add comment like support with aggregation

### DIFF
--- a/src/main/java/org/example/expert/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/expert/domain/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package org.example.expert.domain.comment.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.comment.dto.request.CommentSaveRequest;
+import org.example.expert.domain.comment.dto.response.CommentLikeResponse;
 import org.example.expert.domain.comment.dto.response.CommentResponse;
 import org.example.expert.domain.comment.dto.response.CommentSaveResponse;
 import org.example.expert.domain.comment.service.CommentService;
@@ -28,8 +29,20 @@ public class CommentController {
         return ResponseEntity.ok(commentService.saveComment(authUser, todoId, commentSaveRequest));
     }
 
+    @PostMapping("/todos/{todoId}/comments/{commentId}/likes")
+    public ResponseEntity<CommentLikeResponse> toggleLike(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable long todoId,
+            @PathVariable long commentId
+    ) {
+        return ResponseEntity.ok(commentService.toggleLike(authUser, todoId, commentId));
+    }
+
     @GetMapping("/todos/{todoId}/comments")
-    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable long todoId) {
-        return ResponseEntity.ok(commentService.getComments(todoId));
+    public ResponseEntity<List<CommentResponse>> getComments(
+            @AuthenticationPrincipal(required = false) AuthUser authUser,
+            @PathVariable long todoId
+    ) {
+        return ResponseEntity.ok(commentService.getComments(todoId, authUser));
     }
 }

--- a/src/main/java/org/example/expert/domain/comment/dto/response/CommentLikeResponse.java
+++ b/src/main/java/org/example/expert/domain/comment/dto/response/CommentLikeResponse.java
@@ -1,0 +1,17 @@
+package org.example.expert.domain.comment.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class CommentLikeResponse {
+
+    private final Long commentId;
+    private final long likeCount;
+    private final boolean liked;
+
+    public CommentLikeResponse(Long commentId, long likeCount, boolean liked) {
+        this.commentId = commentId;
+        this.likeCount = likeCount;
+        this.liked = liked;
+    }
+}

--- a/src/main/java/org/example/expert/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/org/example/expert/domain/comment/dto/response/CommentResponse.java
@@ -9,10 +9,14 @@ public class CommentResponse {
     private final Long id;
     private final String contents;
     private final UserResponse user;
+    private final long likeCount;
+    private final boolean liked;
 
-    public CommentResponse(Long id, String contents, UserResponse user) {
+    public CommentResponse(Long id, String contents, UserResponse user, long likeCount, boolean liked) {
         this.id = id;
         this.contents = contents;
         this.user = user;
+        this.likeCount = likeCount;
+        this.liked = liked;
     }
 }

--- a/src/main/java/org/example/expert/domain/comment/entity/CommentLike.java
+++ b/src/main/java/org/example/expert/domain/comment/entity/CommentLike.java
@@ -1,0 +1,33 @@
+package org.example.expert.domain.comment.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.expert.domain.common.entity.Timestamped;
+import org.example.expert.domain.user.entity.User;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "comment_likes", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_comment_like_comment_user", columnNames = {"comment_id", "user_id"})
+})
+public class CommentLike extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public CommentLike(Comment comment, User user) {
+        this.comment = comment;
+        this.user = user;
+    }
+}

--- a/src/main/java/org/example/expert/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/org/example/expert/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,32 @@
+package org.example.expert.domain.comment.repository;
+
+import org.example.expert.domain.comment.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    @Query("SELECT cl FROM CommentLike cl WHERE cl.comment.id = :commentId AND cl.user.id = :userId")
+    Optional<CommentLike> findByCommentIdAndUserId(@Param("commentId") Long commentId, @Param("userId") Long userId);
+
+    @Query("SELECT COUNT(cl.id) FROM CommentLike cl WHERE cl.comment.id = :commentId")
+    long countByCommentId(@Param("commentId") Long commentId);
+
+    @Query("SELECT cl.comment.id AS commentId, COUNT(cl.id) AS likeCount " +
+            "FROM CommentLike cl " +
+            "WHERE cl.comment.id IN :commentIds " +
+            "GROUP BY cl.comment.id")
+    List<CommentLikeCount> countByCommentIdIn(@Param("commentIds") Collection<Long> commentIds);
+
+    List<CommentLike> findByUser_IdAndComment_IdIn(Long userId, Collection<Long> commentIds);
+
+    interface CommentLikeCount {
+        Long getCommentId();
+        long getLikeCount();
+    }
+}

--- a/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,111 @@
+package org.example.expert.domain.comment.service;
+
+import org.example.expert.domain.comment.dto.response.CommentLikeResponse;
+import org.example.expert.domain.comment.dto.response.CommentResponse;
+import org.example.expert.domain.comment.entity.Comment;
+import org.example.expert.domain.comment.entity.CommentLike;
+import org.example.expert.domain.comment.repository.CommentLikeRepository;
+import org.example.expert.domain.comment.repository.CommentRepository;
+import org.example.expert.domain.common.dto.AuthUser;
+import org.example.expert.domain.todo.entity.Todo;
+import org.example.expert.domain.todo.repository.TodoRepository;
+import org.example.expert.domain.user.entity.User;
+import org.example.expert.domain.user.enums.UserRole;
+import org.example.expert.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class CommentServiceTest {
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TodoRepository todoRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
+
+    private User author;
+    private Todo todo;
+    private Comment comment;
+    private AuthUser authUser;
+
+    @BeforeEach
+    void setUp() {
+        author = userRepository.save(new User("author@example.com", "password", "author", UserRole.ROLE_USER));
+        todo = todoRepository.save(new Todo("title", "contents", "sunny", author));
+        comment = commentRepository.save(new Comment("comment", author, todo));
+        authUser = new AuthUser(author.getId(), author.getEmail(), author.getNickname(), author.getUserRole());
+    }
+
+    @Test
+    void toggleLike_createsLikeAndUpdatesCount() {
+        CommentLikeResponse response = commentService.toggleLike(authUser, todo.getId(), comment.getId());
+
+        assertThat(response.isLiked()).isTrue();
+        assertThat(response.getLikeCount()).isEqualTo(1L);
+        assertThat(commentLikeRepository.countByCommentId(comment.getId())).isEqualTo(1L);
+    }
+
+    @Test
+    void toggleLike_removesExistingLike() {
+        commentService.toggleLike(authUser, todo.getId(), comment.getId());
+
+        CommentLikeResponse response = commentService.toggleLike(authUser, todo.getId(), comment.getId());
+
+        assertThat(response.isLiked()).isFalse();
+        assertThat(response.getLikeCount()).isEqualTo(0L);
+        assertThat(commentLikeRepository.countByCommentId(comment.getId())).isEqualTo(0L);
+    }
+
+    @Test
+    void duplicateLike_preventedByUniqueConstraint() {
+        commentLikeRepository.saveAndFlush(new CommentLike(comment, author));
+
+        assertThatThrownBy(() -> commentLikeRepository.saveAndFlush(new CommentLike(comment, author)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void getComments_returnsAggregatedLikeData() {
+        User otherUser = userRepository.save(new User("other@example.com", "password", "other", UserRole.ROLE_USER));
+        Comment secondComment = commentRepository.save(new Comment("another comment", otherUser, todo));
+
+        commentLikeRepository.save(new CommentLike(comment, author));
+        commentLikeRepository.save(new CommentLike(comment, otherUser));
+        commentLikeRepository.save(new CommentLike(secondComment, otherUser));
+
+        List<CommentResponse> responses = commentService.getComments(todo.getId(), authUser);
+        Map<Long, CommentResponse> responseMap = responses.stream()
+                .collect(Collectors.toMap(CommentResponse::getId, Function.identity()));
+
+        CommentResponse firstResponse = responseMap.get(comment.getId());
+        CommentResponse secondResponse = responseMap.get(secondComment.getId());
+
+        assertThat(firstResponse.getLikeCount()).isEqualTo(2L);
+        assertThat(firstResponse.isLiked()).isTrue();
+        assertThat(secondResponse.getLikeCount()).isEqualTo(1L);
+        assertThat(secondResponse.isLiked()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add a CommentLike entity, repository, and DTOs to store likes with uniqueness guarantees
- update the comment service and controller to expose like counts, liked flags, and a toggle endpoint
- cover the new behaviour with Spring Boot tests for toggling, duplicates, counts, and list responses

## Testing
- gradle test *(fails: could not resolve org.springframework.boot plugin from plugin repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d654476100832b8e6cd5dd76770a51